### PR TITLE
Fix error on saving valid file

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -27,7 +27,7 @@ module.exports =
       lintOnFly: true # must be false for scope: 'project'
       lint: (textEditor) =>
         filePath = textEditor.getPath()
-        return helpers.execNode(@executablePath, [filePath], {stream: 'stderr', throwOnStdErr:false})
+        return helpers.execNode(@executablePath, [filePath], {stream: 'stderr', throwOnStdErr:false, allowEmptyStderr: true})
           .then (output) ->
             results = helpers.parse(output, '(?<type>WARN|ERROR):(?<message>.*) on line (?<line>\\d+)')
             return results.map (r) ->


### PR DESCRIPTION
Fixes #29.

linter-javac encountered and fixed a similar issue
[Error: Process exited with no output, code: 0](https://github.com/AtomLinter/linter-javac/issues/96)

Cursory look is that an upgrade of [sb-exec >= 2.0](https://github.com/steelbrain/exec/blob/dfdef289ad8e2d1aee1cfc7e578663d1ca073822/CHANGELOG.md#200) causes empty stderrr output to trigger an error.

Adding "allowEmptyStderr: true" in the exec prevents the error from being raised when there is no stderr output.

Tested on a valid Dockerfile, no errors. Tested with an error and linter-docker properly reported it.