### PR TITLE
Updating dockerlint dependency to 0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   },
   "dependencies": {
     "atom-linter": "^9.0.0",
-    "dockerlint": "~0.2.0"
+    "dockerlint": "^0.2.2"
   }
 }


### PR DESCRIPTION
Updating dockerlint dependency to 0.2.2, and also changing the range from a `~` to a `^` so that bugfix releases like this are installed automatically.